### PR TITLE
Update to handle Google version requirements

### DIFF
--- a/godot-google-play-billing/build.gradle
+++ b/godot-google-play-billing/build.gradle
@@ -6,12 +6,12 @@ ext.pluginVersionCode = 5
 ext.pluginVersionName = "1.2.0"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
 
     defaultConfig {
-        minSdkVersion 18
-        targetSdkVersion 31
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode pluginVersionCode
         versionName pluginVersionName
     }
@@ -25,6 +25,6 @@ android {
 
 dependencies {
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
-    implementation 'com.android.billingclient:billing:5.2.1'
+    implementation 'com.android.billingclient:billing:7.0.0'
     compileOnly fileTree(dir: 'libs', include: ['godot-lib*.aar'])
 }


### PR DESCRIPTION
Updated godot-google-play-billing to compileSdkVersion & targetSdkVersion 33, minSdkVersion 21 & com.android.billingclient:billing:7.0.0