### PR TITLE
Google Play Billing Library: Update from v5.2.1 to v7.0.0

### DIFF
--- a/GodotGooglePlayBilling.gdap
+++ b/GodotGooglePlayBilling.gdap
@@ -5,4 +5,4 @@ binary_type="local"
 binary="GodotGooglePlayBilling.1.2.0.release.aar"
 
 [dependencies]
-remote=["com.android.billingclient:billing:5.2.1"]
+remote=["com.android.billingclient:billing:7.0.0"]

--- a/godot-google-play-billing/build.gradle
+++ b/godot-google-play-billing/build.gradle
@@ -25,6 +25,6 @@ android {
 
 dependencies {
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
-    implementation 'com.android.billingclient:billing:5.2.1'
+    implementation 'com.android.billingclient:billing:7.0.0'
     compileOnly fileTree(dir: 'libs', include: ['godot-lib*.aar'])
 }


### PR DESCRIPTION
* Fixes: #65.
* Partially supersedes: #66.
* Partially supersedes: #52.

This PR only partially supersedes them, because it doesn't change Android SDK versions, gradle versions, etc. Also doesn't change already deprecated methods in version 5.

Don't have a Google Play dev account, so can't really test, can just confirm that it compiles and doesn't produce different results when using the [iap demo project](https://github.com/godotengine/godot-demo-projects/tree/4.0/mobile/android_iap) without Google Play Console (GodotGooglePlayBilling's only compatible with 4.0 versions and maybe some 4.1 versions, tested with 4.0.4).

With this PR [docs](https://docs.godotengine.org/en/stable/tutorials/platform/android/android_in_app_purchases.html#subscriptions) need to be updated (change `BillingFlowParams.ProrationMode` to `BillingFlowParams.SubscriptionUpdateParams.ReplacementMode`).

This PR also makes `price_change_acknowledged` never emit, API [changed a lot](https://developer.android.com/google/play/billing/price-changes). These changes seem too big to test without Google Play Console, so if anyone wants to salvage this PR, feel free. Can be merged as is, of course after testing, if having `price_change_acknowledged` is not critical.