### PR TITLE
docs: update Zensical theme and markdown configuration

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -6,6 +6,9 @@ repo_url = "https://github.com/godot-sdk-integrations/godot-google-play-billing"
 repo_name = "GodotGooglePlayBilling"
 copyright = "Copyright &copy; 2020 Godot Engine Contributors"
 
+use_directory_urls = false
+edit_uri  = "edit/master/docs/"
+
 nav = [
   "index.md",
   "Installation.md",
@@ -26,15 +29,37 @@ features = [
   "navigation.instant",
   "navigation.instant.progress",
   "navigation.top",
-  "search.highlight"
+  "search.highlight",
+  "content.action.edit",
+  "content.action.view"
 ]
 
 [[project.theme.palette]]
 scheme = "default"
 toggle.icon = "lucide/sun"
 toggle.name = "Switch to dark mode"
+media = "(prefers-color-scheme: light)"
 
 [[project.theme.palette]]
 scheme = "slate"
 toggle.icon = "lucide/moon"
 toggle.name = "Switch to light mode"
+media = "(prefers-color-scheme: dark)"
+
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.tables]
+[project.markdown_extensions.pymdownx.inlinehilite]
+[project.markdown_extensions.pymdownx.snippets]
+[project.markdown_extensions.pymdownx.superfences]
+
+[project.markdown_extensions.pymdownx.emoji]
+emoji_index = "zensical.extensions.emoji.twemoji"
+emoji_generator = "zensical.extensions.emoji.to_svg"
+
+[project.markdown_extensions.toc]
+toc_depth = 0
+
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+line_spans = "__span"
+pygments_lang_class = true

--- a/zensical.toml
+++ b/zensical.toml
@@ -45,21 +45,3 @@ scheme = "slate"
 toggle.icon = "lucide/moon"
 toggle.name = "Switch to light mode"
 media = "(prefers-color-scheme: dark)"
-
-[project.markdown_extensions.admonition]
-[project.markdown_extensions.tables]
-[project.markdown_extensions.pymdownx.inlinehilite]
-[project.markdown_extensions.pymdownx.snippets]
-[project.markdown_extensions.pymdownx.superfences]
-
-[project.markdown_extensions.pymdownx.emoji]
-emoji_index = "zensical.extensions.emoji.twemoji"
-emoji_generator = "zensical.extensions.emoji.to_svg"
-
-[project.markdown_extensions.toc]
-toc_depth = 0
-
-[project.markdown_extensions.pymdownx.highlight]
-anchor_linenums = true
-line_spans = "__span"
-pygments_lang_class = true


### PR DESCRIPTION
Update documentation setup with improved theme and markdown features.

- Disabled directory URLs
- Set edit URI for docs
- Configured light/dark palettes
- Enabled markdown extensions:
  - `admonition`
  - `tables`
  - `pymdownx.inlinehilite`
  - `pymdownx.snippets`
  - `pymdownx.superfences`
  - `pymdownx.emoji`
  - `toc`
  - `pymdownx.highlight`