### PR TITLE
Update Godot 3 billing plugin to Play Billing 8.3.0

### DIFF
--- a/GodotGooglePlayBilling.gdap
+++ b/GodotGooglePlayBilling.gdap
@@ -2,7 +2,7 @@
 
 name="GodotGooglePlayBilling"
 binary_type="local"
-binary="GodotGooglePlayBilling.1.3.0.release.aar"
+binary="GodotGooglePlayBilling.1.4.0.release.aar"
 
 [dependencies]
-remote=["com.android.billingclient:billing:7.0.0"]
+remote=["com.android.billingclient:billing:8.3.0"]

--- a/godot-google-play-billing/build.gradle
+++ b/godot-google-play-billing/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'com.android.library'
 }
 
-ext.pluginVersionCode = 6
-ext.pluginVersionName = "1.3.0"
+ext.pluginVersionCode = 7
+ext.pluginVersionName = "1.4.0"
 
 android {
     namespace 'org.godotengine.godot.plugin.googleplaybilling'
@@ -30,6 +30,6 @@ android {
 
 dependencies {
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
-    implementation 'com.android.billingclient:billing:7.0.0'
+    implementation 'com.android.billingclient:billing:8.3.0'
     compileOnly fileTree(dir: 'libs', include: ['godot-lib*.aar'])
 }

--- a/godot-google-play-billing/src/main/java/org/godotengine/godot/plugin/googleplaybilling/GodotGooglePlayBilling.java
+++ b/godot-google-play-billing/src/main/java/org/godotengine/godot/plugin/googleplaybilling/GodotGooglePlayBilling.java
@@ -50,13 +50,16 @@ import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.ConsumeParams;
 import com.android.billingclient.api.ConsumeResponseListener;
 import com.android.billingclient.api.PendingPurchasesParams;
+import com.android.billingclient.api.ProductDetails;
+import com.android.billingclient.api.ProductDetailsResponseListener;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.PurchasesResponseListener;
 import com.android.billingclient.api.PurchasesUpdatedListener;
-import com.android.billingclient.api.SkuDetails;
-import com.android.billingclient.api.SkuDetailsParams;
-import com.android.billingclient.api.SkuDetailsResponseListener;
+import com.android.billingclient.api.QueryProductDetailsParams;
+import com.android.billingclient.api.QueryProductDetailsResult;
+import com.android.billingclient.api.QueryPurchasesParams;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -65,7 +68,8 @@ import java.util.Set;
 public class GodotGooglePlayBilling extends GodotPlugin implements PurchasesUpdatedListener, BillingClientStateListener {
 
 	private final BillingClient billingClient;
-	private final HashMap<String, SkuDetails> skuDetailsCache = new HashMap<>(); // sku → SkuDetails
+	// Billing 8 removed SkuDetails. Keep the legacy cache/API names, but store ProductDetails keyed by sku.
+	private final HashMap<String, ProductDetails> skuDetailsCache = new HashMap<>(); // sku -> ProductDetails
 	private boolean calledStartConnection;
 	private String obfuscatedAccountId;
 	private String obfuscatedProfileId;
@@ -73,12 +77,13 @@ public class GodotGooglePlayBilling extends GodotPlugin implements PurchasesUpda
 	public GodotGooglePlayBilling(Godot godot) {
 		super(godot);
 
-		PendingPurchasesParams pendingPurchasesParams = 
+		PendingPurchasesParams pendingPurchasesParams =
 			PendingPurchasesParams.newBuilder().enableOneTimeProducts().build();
 
 		billingClient = BillingClient
 								.newBuilder(getActivity())
 								.enablePendingPurchases(pendingPurchasesParams)
+								.enableAutoServiceReconnection()
 								.setListener(this)
 								.build();
 		calledStartConnection = false;
@@ -105,7 +110,11 @@ public class GodotGooglePlayBilling extends GodotPlugin implements PurchasesUpda
 
 	@UsedByGodot
 	public void queryPurchases(String type) {
-		billingClient.queryPurchasesAsync(type, new PurchasesResponseListener() {
+		QueryPurchasesParams params = QueryPurchasesParams.newBuilder()
+				.setProductType(type)
+				.build();
+
+		billingClient.queryPurchasesAsync(params, new PurchasesResponseListener() {
 			@Override
 			public void onQueryPurchasesResponse(BillingResult billingResult,
 					List<Purchase> purchaseList) {
@@ -124,19 +133,27 @@ public class GodotGooglePlayBilling extends GodotPlugin implements PurchasesUpda
 	}
 	@UsedByGodot
 	public void querySkuDetails(final String[] list, String type) {
-		List<String> skuList = Arrays.asList(list);
+		// Billing 8 queries ProductDetails. The Godot 3 API still exposes these ids as skus.
+		List<QueryProductDetailsParams.Product> skuList = new ArrayList<>();
+		for (String sku : list) {
+			skuList.add(QueryProductDetailsParams.Product.newBuilder()
+					.setProductId(sku)
+					.setProductType(type)
+					.build());
+		}
 
-		SkuDetailsParams.Builder params = SkuDetailsParams.newBuilder()
-												  .setSkusList(skuList)
-												  .setType(type);
+		QueryProductDetailsParams params = QueryProductDetailsParams.newBuilder()
+				.setProductList(skuList)
+				.build();
 
-		billingClient.querySkuDetailsAsync(params.build(), new SkuDetailsResponseListener() {
+		billingClient.queryProductDetailsAsync(params, new ProductDetailsResponseListener() {
 			@Override
-			public void onSkuDetailsResponse(BillingResult billingResult,
-					List<SkuDetails> skuDetailsList) {
+			public void onProductDetailsResponse(BillingResult billingResult,
+					QueryProductDetailsResult queryProductDetailsResult) {
 				if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK) {
-					for (SkuDetails skuDetails : skuDetailsList) {
-						skuDetailsCache.put(skuDetails.getSku(), skuDetails);
+					List<ProductDetails> skuDetailsList = queryProductDetailsResult.getProductDetailsList();
+					for (ProductDetails skuDetails : skuDetailsList) {
+						skuDetailsCache.put(skuDetails.getProductId(), skuDetails);
 					}
 					emitSignal("sku_details_query_completed", (Object)GooglePlayBillingUtils.convertSkuDetailsListToDictionaryObjectArray(skuDetailsList));
 				} else {
@@ -204,8 +221,6 @@ public class GodotGooglePlayBilling extends GodotPlugin implements PurchasesUpda
 			return returnValue;
 		}
 
-		SkuDetails skuDetails = skuDetailsCache.get(sku);
-		
 		Dictionary returnValue = new Dictionary();
 		returnValue.put("status", 0); // OK = 0
 		return returnValue;
@@ -229,9 +244,41 @@ public class GodotGooglePlayBilling extends GodotPlugin implements PurchasesUpda
 			return returnValue;
 		}
 
-		SkuDetails skuDetails = skuDetailsCache.get(sku);
+		ProductDetails skuDetails = skuDetailsCache.get(sku);
+		// Billing 8 launches purchases with ProductDetailsParams instead of setSkuDetails.
+		// Pick the default offer token so the legacy purchase(sku) method still works.
+		BillingFlowParams.ProductDetailsParams.Builder skuDetailsParamsBuilder =
+				BillingFlowParams.ProductDetailsParams.newBuilder()
+						.setProductDetails(skuDetails);
+
+		if (BillingClient.ProductType.SUBS.equals(skuDetails.getProductType())) {
+			List<ProductDetails.SubscriptionOfferDetails> offers = skuDetails.getSubscriptionOfferDetails();
+			if (offers != null && !offers.isEmpty()) {
+				ProductDetails.SubscriptionOfferDetails selectedOffer = offers.get(0);
+				// Billing 8 uses a null offer id for the regular base plan. Prefer it for the legacy purchase(sku) path.
+				for (ProductDetails.SubscriptionOfferDetails offer : offers) {
+					if (offer.getOfferId() == null) {
+						selectedOffer = offer;
+						break;
+					}
+				}
+				String offerToken = selectedOffer.getOfferToken();
+				if (offerToken != null && !offerToken.isEmpty()) {
+					skuDetailsParamsBuilder.setOfferToken(offerToken);
+				}
+			}
+		} else {
+			ProductDetails.OneTimePurchaseOfferDetails offer = skuDetails.getOneTimePurchaseOfferDetails();
+			if (offer != null) {
+				String offerToken = offer.getOfferToken();
+				if (offerToken != null && !offerToken.isEmpty()) {
+					skuDetailsParamsBuilder.setOfferToken(offerToken);
+				}
+			}
+		}
+
 		BillingFlowParams.Builder purchaseParamsBuilder = BillingFlowParams.newBuilder();
-		purchaseParamsBuilder.setSkuDetails(skuDetails);
+		purchaseParamsBuilder.setProductDetailsParamsList(Arrays.asList(skuDetailsParamsBuilder.build()));
 		if (!obfuscatedAccountId.isEmpty()) {
 			purchaseParamsBuilder.setObfuscatedAccountId(obfuscatedAccountId);
 		}

--- a/godot-google-play-billing/src/main/java/org/godotengine/godot/plugin/googleplaybilling/utils/GooglePlayBillingUtils.java
+++ b/godot-google-play-billing/src/main/java/org/godotengine/godot/plugin/googleplaybilling/utils/GooglePlayBillingUtils.java
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  GooglePlayBillingUtils.java                                                    */
+/*  GooglePlayBillingUtils.java                                          */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -32,10 +32,10 @@ package org.godotengine.godot.plugin.googleplaybilling.utils;
 
 import org.godotengine.godot.Dictionary;
 
+import com.android.billingclient.api.BillingClient;
+import com.android.billingclient.api.ProductDetails;
 import com.android.billingclient.api.Purchase;
-import com.android.billingclient.api.SkuDetails;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class GooglePlayBillingUtils {
@@ -49,10 +49,10 @@ public class GooglePlayBillingUtils {
 		dictionary.put("purchase_token", purchase.getPurchaseToken());
 		dictionary.put("quantity", purchase.getQuantity());
 		dictionary.put("signature", purchase.getSignature());
-		// PBL V4 replaced getSku with getSkus to support multi-sku purchases,
-		// use the first entry for "sku" and generate an array for "skus"
-		ArrayList<String> skus = purchase.getSkus();
-		dictionary.put("sku", skus.get(0));
+		// PBL V4 replaced getSku with getSkus to support multi-sku purchases.
+		// PBL V7 replaced getSkus with getProducts.
+		List<String> skus = purchase.getProducts();
+		dictionary.put("sku", skus.isEmpty() ? "" : skus.get(0));
 		String[] skusArray = skus.toArray(new String[0]);
 		dictionary.put("skus", skusArray);
 		dictionary.put("is_acknowledged", purchase.isAcknowledged());
@@ -60,24 +60,60 @@ public class GooglePlayBillingUtils {
 		return dictionary;
 	}
 
-	public static Dictionary convertSkuDetailsToDictionary(SkuDetails details) {
+	public static Dictionary convertSkuDetailsToDictionary(ProductDetails details) {
 		Dictionary dictionary = new Dictionary();
-		dictionary.put("sku", details.getSku());
+		dictionary.put("sku", details.getProductId());
 		dictionary.put("title", details.getTitle());
 		dictionary.put("description", details.getDescription());
-		dictionary.put("price", details.getPrice());
-		dictionary.put("price_currency_code", details.getPriceCurrencyCode());
-		dictionary.put("price_amount_micros", details.getPriceAmountMicros());
-		dictionary.put("free_trial_period", details.getFreeTrialPeriod());
-		dictionary.put("icon_url", details.getIconUrl());
-		dictionary.put("introductory_price", details.getIntroductoryPrice());
-		dictionary.put("introductory_price_amount_micros", details.getIntroductoryPriceAmountMicros());
-		dictionary.put("introductory_price_cycles", details.getIntroductoryPriceCycles());
-		dictionary.put("introductory_price_period", details.getIntroductoryPricePeriod());
-		dictionary.put("original_price", details.getOriginalPrice());
-		dictionary.put("original_price_amount_micros", details.getOriginalPriceAmountMicros());
-		dictionary.put("subscription_period", details.getSubscriptionPeriod());
-		dictionary.put("type", details.getType());
+		// ProductDetails no longer exposes every flattened SkuDetails field.
+		// Keep the legacy dictionary keys and use old-type defaults when there is no direct equivalent.
+		dictionary.put("price", "");
+		dictionary.put("price_currency_code", "");
+		dictionary.put("price_amount_micros", 0L);
+		dictionary.put("free_trial_period", "");
+		dictionary.put("icon_url", "");
+		dictionary.put("introductory_price", "");
+		dictionary.put("introductory_price_amount_micros", 0L);
+		dictionary.put("introductory_price_cycles", 0);
+		dictionary.put("introductory_price_period", "");
+		dictionary.put("original_price", "");
+		dictionary.put("original_price_amount_micros", 0L);
+		dictionary.put("subscription_period", "");
+		dictionary.put("type", details.getProductType());
+
+		if (BillingClient.ProductType.INAPP.equals(details.getProductType())) {
+			ProductDetails.OneTimePurchaseOfferDetails offer = details.getOneTimePurchaseOfferDetails();
+			if (offer != null) {
+				dictionary.put("price", offer.getFormattedPrice());
+				dictionary.put("price_currency_code", offer.getPriceCurrencyCode());
+				dictionary.put("price_amount_micros", offer.getPriceAmountMicros());
+				Long fullPriceMicros = offer.getFullPriceMicros();
+				if (fullPriceMicros != null) {
+					dictionary.put("original_price_amount_micros", fullPriceMicros);
+				}
+			}
+		} else if (BillingClient.ProductType.SUBS.equals(details.getProductType())) {
+			List<ProductDetails.SubscriptionOfferDetails> offers = details.getSubscriptionOfferDetails();
+			if (offers != null && !offers.isEmpty()) {
+				ProductDetails.SubscriptionOfferDetails selectedOffer = offers.get(0);
+				// Billing 8 uses a null offer id for the regular base plan. Prefer it for legacy sku details.
+				for (ProductDetails.SubscriptionOfferDetails offer : offers) {
+					if (offer.getOfferId() == null) {
+						selectedOffer = offer;
+						break;
+					}
+				}
+				List<ProductDetails.PricingPhase> phases = selectedOffer.getPricingPhases().getPricingPhaseList();
+				if (phases != null && !phases.isEmpty()) {
+					ProductDetails.PricingPhase pricingPhase = phases.get(0);
+					dictionary.put("price", pricingPhase.getFormattedPrice());
+					dictionary.put("price_currency_code", pricingPhase.getPriceCurrencyCode());
+					dictionary.put("price_amount_micros", pricingPhase.getPriceAmountMicros());
+					dictionary.put("subscription_period", pricingPhase.getBillingPeriod());
+				}
+			}
+		}
+
 		return dictionary;
 	}
 
@@ -91,7 +127,7 @@ public class GooglePlayBillingUtils {
 		return purchaseDictionaries;
 	}
 
-	public static Object[] convertSkuDetailsListToDictionaryObjectArray(List<SkuDetails> skuDetails) {
+	public static Object[] convertSkuDetailsListToDictionaryObjectArray(List<ProductDetails> skuDetails) {
 		Object[] skuDetailsDictionaries = new Object[skuDetails.size()];
 
 		for (int i = 0; i < skuDetails.size(); i++) {


### PR DESCRIPTION
This is my attempt to update the 1.x branch (that is compatible with Godot 3.x) to Billing library 8.3.0. Starting from 31 Aug 2026, Google requires the use of Billing library 8.0.0 or later.

The biggest changes are:
- Upgraded Google Play Billing from 7.0.0 to 8.3.0.
- Replaced removed Billing 8 APIs: SkuDetails/querySkuDetailsAsync now use ProductDetails/queryProductDetailsAsync.
- Updated purchase flow to use BillingFlowParams.ProductDetailsParams with offer tokens.
- Kept the old Godot 3 / 1.x public API names like querySkuDetails, purchase(sku), sku, and skus.
- Added minimal default-offer handling: regular subscription base plan first, fallback to first eligible offer.
- Preserved legacy dictionary keys, filling unavailable old SkuDetails fields with old-style defaults.
 - Updated version/artifact metadata to 1.4.0.

I have not yet fully tested the changes, but plan on doing so soon. I wanted to get the ball rolling already. Feel free to disregard this pull request until I've done more tests.

Note that I had help from a clanker (codex) to do this. I did review the code though!

There is an older pull request attempting the same thing, but it seems unfinished: https://github.com/godot-sdk-integrations/godot-google-play-billing/pull/83